### PR TITLE
Support v0.5.0

### DIFF
--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -27,7 +27,7 @@ jobs:
       issues: 'write' # for modifying Issues
     steps:
       - name: Update the issue for the workflow
-        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -18,3 +18,16 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/create-signing-events@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [create-signing-events]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -34,7 +34,7 @@ jobs:
       issues: 'write' # for modifying Issues
     steps:
       - name: Update the issue for the workflow
-        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -13,12 +13,10 @@ on:
 jobs:
   online-sign:
     runs-on: ubuntu-latest
-
     permissions:
       id-token: 'write' # for OIDC identity access
       contents: 'write' # for commiting snapshot/timestamp changes
       actions: 'write' # for dispatching publish workflow
-
     steps:
       - id: online-sign
         uses: theupdateframework/tuf-on-ci/actions/online-sign@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
@@ -26,3 +24,17 @@ jobs:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [online-sign]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@7a9bd943aa5e5175aeb8502edcc6c1c02d398e10 # v4.0.2
 
-  test:
+  test-deployed-repository:
     needs: deploy
     permissions:
       issues: 'write' # for modifying Issues
@@ -43,7 +43,7 @@ jobs:
 
   update-issue:
     runs-on: ubuntu-latest
-    needs: [build, deploy, test]
+    needs: [build, deploy, test-deployed-repository]
     if: always() && !cancelled()
     permissions:
       issues: 'write' # for modifying Issues

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       issues: 'write' # for modifying Issues
     steps:
       - name: Update the issue for the workflow
-        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,3 +34,22 @@ jobs:
       - name: Deploy TUF-on-CI repository to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@7a9bd943aa5e5175aeb8502edcc6c1c02d398e10 # v4.0.2
+
+  test:
+    needs: deploy
+    permissions:
+      issues: 'write' # for modifying Issues
+    uses: ./.github/workflows/test.yml
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [build, deploy, test]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Smoke test TUF-on-CI repository with a TUF client
-        uses: jku/tuf-on-ci/actions/test-repository@issue-mgmt # FIXME repo & ref
+        uses: theupdateframework/tuf-on-ci/actions/test-repository@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
 
   update-issue:
     runs-on: ubuntu-latest
@@ -24,7 +24,7 @@ jobs:
       issues: 'write' # for modifying Issues
     steps:
       - name: Update the issue for the workflow
-        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
   smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Smoke test repository with a client
+      - name: Smoke test TUF-on-CI repository with a TUF client
         uses: jku/tuf-on-ci/actions/test-repository@issue-mgmt # FIXME repo & ref
 
   update-issue:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: TUF-on-CI repository tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4,10,16,22 * * *'
+
+permissions: {}
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Smoke test repository with a client
+        uses: jku/tuf-on-ci/actions/test-repository@issue-mgmt # FIXME repo & ref
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [smoke-test]
+    # During workflow_call, caller updates issue
+    if: always() && !cancelled() && github.workflow == 'test.yml'
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: jku/tuf-on-ci/actions/update-issue@issue-mgmt # FIXME repo & ref
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
DRAFT: companion PR for https://github.com/theupdateframework/tuf-on-ci/pull/176

This combines two things:
* Adds a new workflow test (the workflow is run on cron but also used from publish)
* Starts using update-issue action in all workflows except signing-event

Let's review this as part of https://github.com/theupdateframework/tuf-on-ci/pull/176 