### PR TITLE
Fix test workflow update-issue condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [smoke-test]
     # During workflow_call, caller updates issue
-    if: always() && !cancelled() && github.workflow == 'test.yml'
+    if: always() && !cancelled() && github.workflow == 'TUF-on-CI repository tests'
     permissions:
       issues: 'write' # for modifying Issues
     steps:


### PR DESCRIPTION
`github.workflow` is actually the name of the workflow if the name is set.

There may be a better way to tell workflow_call from other event types but this is what I have for now.

Fixes #18