### PR TITLE
publish: Tweak names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: TUF-on-CI publish to GitHub Pages
+name: TUF-on-CI publish
 
 permissions: {}
 
@@ -21,7 +21,7 @@ jobs:
           gh_pages: true
           ref: ${{ inputs.ref }}
 
-  deploy:
+  deploy-to-pages:
     permissions:
       pages: write
       id-token: write # for authenticating to GH Pages
@@ -36,14 +36,14 @@ jobs:
         uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4 # v4.0.4
 
   test-deployed-repository:
-    needs: deploy
+    needs: deploy-to-pages
     permissions:
       issues: 'write' # for modifying Issues
     uses: ./.github/workflows/test.yml
 
   update-issue:
     runs-on: ubuntu-latest
-    needs: [build, deploy, test-deployed-repository]
+    needs: [build, deploy-to-pages, test-deployed-repository]
     if: always() && !cancelled()
     permissions:
       issues: 'write' # for modifying Issues


### PR DESCRIPTION
Since we want "publish" to be customizable we should not call it "publish to Pages"