### PR TITLE
fix: smoke-test read permission

### DIFF
--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -11,8 +11,8 @@ jobs:
   create-signing-events:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'write' # for committing to signing event branch
-      actions: 'write' # for dispatching signing event workflow
+      contents: write # for committing to signing event branch
+      actions: write # for dispatching signing event workflow
     steps:
       - name: Create signing events for offline version bumps
         uses: theupdateframework/tuf-on-ci/actions/create-signing-events@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0
@@ -24,7 +24,7 @@ jobs:
     needs: [create-signing-events]
     if: always() && !cancelled()
     permissions:
-      issues: 'write' # for modifying Issues
+      issues: write # for modifying Issues
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -14,9 +14,9 @@ jobs:
   online-sign:
     runs-on: ubuntu-latest
     permissions:
-      id-token: 'write' # for OIDC identity access
-      contents: 'write' # for commiting snapshot/timestamp changes
-      actions: 'write' # for dispatching publish workflow
+      id-token: write # for OIDC identity access
+      contents: write # for commiting snapshot/timestamp changes
+      actions: write # for dispatching publish workflow
     steps:
       - id: online-sign
         uses: theupdateframework/tuf-on-ci/actions/online-sign@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0
@@ -31,7 +31,7 @@ jobs:
     needs: [online-sign]
     if: always() && !cancelled()
     permissions:
-      issues: 'write' # for modifying Issues
+      issues: write # for modifying Issues
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
   test-deployed-repository:
     needs: deploy-to-pages
     permissions:
-      issues: 'write' # for modifying Issues
+      issues: write # for modifying Issues
     uses: ./.github/workflows/test.yml
 
   update-issue:
@@ -46,7 +46,7 @@ jobs:
     needs: [build, deploy-to-pages, test-deployed-repository]
     if: always() && !cancelled()
     permissions:
-      issues: 'write' # for modifying Issues
+      issues: write # for modifying Issues
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ permissions: {}
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for checking out the repository
     steps:
       - name: Smoke test TUF-on-CI repository with a TUF client
         uses: theupdateframework/tuf-on-ci/actions/test-repository@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     # During workflow_call, caller updates issue
     if: always() && !cancelled() && github.workflow == 'TUF-on-CI repository tests'
     permissions:
-      issues: 'write' # for modifying Issues
+      issues: write # for modifying Issues
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0


### PR DESCRIPTION
## Summary
* adds `contents: read` permission to `smoke-test` job to access private repositories
* cleans up permissions with consistent formatting

fixes https://github.com/theupdateframework/tuf-on-ci-template/issues/24
