### PR TITLE
fix: publish workflow test permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
   test-deployed-repository:
     needs: deploy-to-pages
     permissions:
+      contents: read # for checking out the repository
       issues: write # for modifying Issues
     uses: ./.github/workflows/test.yml
 


### PR DESCRIPTION
## Summary
A little hard to test github actions and ended up finding a bug from https://github.com/theupdateframework/tuf-on-ci-template/pull/25 where `publish` calls the test without `contents: read`

* fixes bug where `publish.yml` calls `test.yml` without `contents: read` permissions

```sh
Error calling workflow '.github/workflows/test.yml@5bdbcc8094b67c489fa12f9b746ab31add7b0972'. The nested job 'smoke-test' is requesting 'contents: read', but is only allowed 'contents: none'.
```

part of https://github.com/theupdateframework/tuf-on-ci-template/issues/24
