### PR TITLE
fix: private repo permissions v0.10.0

### DIFF
--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -25,6 +25,7 @@ jobs:
     if: always() && !cancelled()
     permissions:
       issues: write # for modifying Issues
+      contents: read # for checking out the repository
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@a486e2d6fcf93af4cb0f479e6a280f34125647d6 # v0.10.0

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -25,13 +25,13 @@ jobs:
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
-
   update-issue:
     runs-on: ubuntu-latest
     needs: [online-sign]
     if: always() && !cancelled()
     permissions:
       issues: write # for modifying Issues
+      contents: read # for checking out the repository
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@a486e2d6fcf93af4cb0f479e6a280f34125647d6 # v0.10.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     permissions:
       contents: read
+      pages: read
     runs-on: ubuntu-latest
     steps:
       - id: build-and-upload-repository
@@ -48,6 +49,7 @@ jobs:
     if: always() && !cancelled()
     permissions:
       issues: write # for modifying Issues
+      contents: read # for checking out the repository
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@a486e2d6fcf93af4cb0f479e6a280f34125647d6 # v0.10.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
     if: always() && !cancelled() && github.workflow == 'TUF-on-CI repository tests'
     permissions:
       issues: write # for modifying Issues
+      contents: read # for checking out the repository
     steps:
       - name: Update the issue for the workflow
         uses: theupdateframework/tuf-on-ci/actions/update-issue@a486e2d6fcf93af4cb0f479e6a280f34125647d6 # v0.10.0


### PR DESCRIPTION
Hi 👋 , this PR fixes permissions errors for a private/internal TUF repos using `tuf-on-ci` templates from v0.10.0

It looks like there is a new `actions/checkout` in the `update-issue` workflow ([here](https://github.com/theupdateframework/tuf-on-ci/pull/270/files#diff-5da32535b86034c4db8fb394b99f46102596cf856e0d3d216daef30f12f183ebR22-R23)) that needs `contents: read`

Also, the `jekyll-build-pages` action needs `pages: read` for private/internal repos for the [upload-repository workflow](https://github.com/theupdateframework/tuf-on-ci/blob/b2c4175c113de1d2362fde31469f8a45a3d5b8f1/actions/upload-repository/action.yml#L48).