### PR TITLE
Add pull_request trigger for test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '17 4,10,16,22 * * *'
+  pull_request:
+    paths: ['.github/workflows/*']
 
 permissions: {}
 


### PR DESCRIPTION
This makes it easier to validate workflow changes. The event triggers if any workflow is changed: This might not always be useful but should not hurt, and covers the sort of cases that e.g. sigstore root-signing uses: custom test workflows that get called from the test workflow.