### PR TITLE
signing-event: Add commented out if-clause

### DIFF
--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -19,6 +19,7 @@ jobs:
 
     steps:
       - name: Signing event
+        # if: github.repository_owner == 'insert-owner-name-here' # avoid running in forks
         uses: theupdateframework/tuf-on-ci/actions/signing-event@95dc66aba6102bbe911ef93c69395ff62ed69bd4 # v0.11.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We would like to only run in the upstream repository (and not in the signer forks) but we can't do that automatically: Add a commented out if-clause for that.