### PR TITLE
Pass parameters for all supported online signing methods

### DIFF
--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -24,6 +24,11 @@ jobs:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          aws_region: ${{ vars.AWS_REGION }}
+          aws_role_to_assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
   update-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The online-sign action does not work out-of-the-box without modification for the AWS KMS or Azure Key Vault signing methods when following the configuration instructions in tuf-on-ci/docs/ONLINE-SIGNING-SETUP.md. This update passes all parameters from documented repository variables or secrets for supported online signing methods by default.

This update has a side-effect of making merges of template workflow updates into existing repositories easier.

If this PR is accepted, the tuf-on-ci/doc/ONLINE-SIGNING-SETUP.md instructions for Azure Key Vault should have step 3 describing workflow modifications removed.

If this PR is not accepted, the instructions for AWS KMS should be updated to include modification instructions to pass the AWS parameters instead of those for GCP.